### PR TITLE
Allow skipping the java installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cerebro_ldap_auth:
 
 ## Dependencies
 
-This role will also install the following Dependencies
+This role will also install the following Dependencies unless the `cerebro_skip_java_install: true` variable is set.
 
 * geerlingguy.java
   * jdk 1.8.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ cerebro_http_address: 0.0.0.0
 cerebro_local_data_path: ./cerebro.db
 cerebro_play_secret: ki:s:[[@=Ag?QI`W2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N
 cerebro_rest_history: 50
+
+cerebro_skip_java_install: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -185,4 +185,5 @@ galaxy_info:
 
 dependencies:
   - role: geerlingguy.java
+    when: "cerebro_skip_java_install != true"
     java_packages: java-1.8.0-openjdk


### PR DESCRIPTION
This change lets you define `cerebro_skip_java_install: true` to disable the `geerlingguy.java` role.

My configuration separately installs java and `geerlingguy.java` doesn't work with ubuntu 18.04.